### PR TITLE
Fix the name of Turkish language

### DIFF
--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -8,7 +8,7 @@
         "da": "Dansk",
         "pl": "Polski",
         "pt_BR": "Portugueses",
-        "tr": "Türk",
+        "tr": "Türkçe",
         "uk": "Українська"
     }
 }


### PR DESCRIPTION
Türkçe is the correct translation for Turkish.
